### PR TITLE
feat: add new option for focusing on the private repo, but not the whole packages in the org

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ VSCode extension for separating imports in Go files into three groups:
 
 * `groupImports.onSave`: automatically group imports on save. Default value is `true`.
 * `groupImports.GoPrivate`: the private packages that will also be included as own packages, eg: "github.com/your-compony/"
+* `groupImports.FocusOnPrivate`: Ignore other packages belonging to the organization. Default value is `false`

--- a/package.json
+++ b/package.json
@@ -44,6 +44,11 @@
           "type": "string",
           "default": "",
           "description": "The go private packages are assumed to be own"
+        },
+        "groupImports.FocusOnPrivate": {
+          "type": "boolean",
+          "default": "",
+          "description": "Focus on packages in this repository. Ignore other packages belonging to the organization."
         }
       }
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,8 +29,12 @@ const resolveRootPackageWithGOPATH = () => {
   return rootPkg;
 };
 
+const FocusOnPrivate = (): boolean => {
+  return workspace.getConfiguration('groupImports').get('FocusOnPrivate') as boolean;
+};
+
 export const resolveRootPackage = () => {
-  if (fileInGOPATH(process.env.GOPATH)) {
+  if (fileInGOPATH(process.env.GOPATH) && !FocusOnPrivate()) {
     return resolveRootPackageWithGOPATH();
   }
 


### PR DESCRIPTION
This plugin works great, but I wish there was a option to make the repository behave the same in GOPATH as it does outside of GOPATH.

Thanks for reviewing